### PR TITLE
correct flags for htslib when found via --with-htslib=/path #26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ compiler:
 #  - clang # Don't compile in clang until openmp errors are resolved.
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew update; 
-        brew install gsl; 
+        brew update;
+        brew install gsl;
         brew install gcc48;
         brew install gettext;
         brew link --force gettext;
@@ -31,8 +31,9 @@ before_install:
         sudo apt-get install -y libhts-dev; 
         sudo apt-get install -y libhts0; 
     fi
-#install:
+install:
 #  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - autoreconf
 addons:
   apt:
     sources:

--- a/Makefile.in
+++ b/Makefile.in
@@ -42,10 +42,10 @@ LDLIBS += @INTLLIBS@
 #@Hsource@BGZIP = $(HTSDIR)/bgzip
 
 
-HTSDIR=@HTSDIR@
+HTSDIR := $(realpath @HTSDIR@)
 
-HTSLIB_CPPFLAGS = -I $(realpath $(HTSDIR))
-HTSLIB_LDFLAGS = -L $(realpath $(HTSDIR))
+HTSLIB_CPPFLAGS = @HTSLIB_CPPFLAGS@
+HTSLIB_LDFLAGS =  @HTSLIB_LDFLAGS@
 @Hinstall@HTSLIB_LIB = -lhts
 
 #LZ4 FLAGS
@@ -53,7 +53,6 @@ HTSLIB_LDFLAGS = -L $(realpath $(HTSDIR))
 LZ4_LIB = -L @LZ4_DIR@ -l llz4
 LZ4_INCLUDE = -I @LZ4_DIR@
 
-	
 export
 
 all:  
@@ -91,7 +90,7 @@ echo:
 debug: 
 	$(MAKE) -C $(SUBDIRS) debug
 .PHONY: dist
-	
+
 test: all
 	$(MAKE) -C $(SUBDIRS) test
 .PHONY: test
@@ -105,7 +104,7 @@ clean:
 	rm -f config.status
 	$(MAKE) -C $(SUBDIRS) clean
 .PHONY: clean
-	
+
 increment:
 	$(MAKE) -C $(SUBDIRS) increment 
 .PHONY: clean

--- a/Makefile.in
+++ b/Makefile.in
@@ -41,9 +41,8 @@ LDLIBS += @INTLLIBS@
 #@Hsource@HTSLIB_LIB = $(HTSLIB)
 #@Hsource@BGZIP = $(HTSDIR)/bgzip
 
-
-HTSDIR := $(realpath @HTSDIR@)
-
+# HTSDIR is not always defined in ax_with_htslib
+#HTSDIR := $(realpath @HTSDIR@)
 HTSLIB_CPPFLAGS = @HTSLIB_CPPFLAGS@
 HTSLIB_LDFLAGS =  @HTSLIB_LDFLAGS@
 @Hinstall@HTSLIB_LIB = -lhts

--- a/m4/ax_with_htslib.m4
+++ b/m4/ax_with_htslib.m4
@@ -102,10 +102,12 @@ esac
 case $ax_cv_htslib_which in
 source)
   ax_cv_htslib=yes
-  HTSLIB_CPPFLAGS="-I$HTSDIR"
-  HTSLIB_LDFLAGS="-L$HTSDIR"
   # We can't use a literal, because $HTSDIR is user-provided and variable
   AC_CONFIG_SUBDIRS($HTSDIR)
+  # translate to absolute, anchor with './'
+  HTSDIR=`cd ./$HTSDIR; pwd`
+  HTSLIB_CPPFLAGS="-I$HTSDIR"
+  HTSLIB_LDFLAGS="-L$HTSDIR"
   ;;
 system)
   AC_CHECK_HEADER([htslib/sam.h],


### PR DESCRIPTION
`HTSDIR` is not always defined by [`AX_WITH_HTSLIB`](https://github.com/LynchLab/MAPGD/blob/master/m4/ax_with_htslib.m4#L129) and when combined with [this](https://github.com/LynchLab/MAPGD/blob/master/Makefile.in#L39-L42) leads to incomplete options for `g++`.

This PR resolves to use the always defined `HTSLIB_CPPFLAGS` and `HTSLIB_LDFLAGS` assuming htslib is installed and found i.e. `--with-htslib` is used.

## References

#26