### PR TITLE
Fixing missing function and parameters

### DIFF
--- a/src/mapgd_0.4/commands/relatedness.h
+++ b/src/mapgd_0.4/commands/relatedness.h
@@ -87,5 +87,8 @@ newton(Relatedness &rel, std::map <Genotype_pair_tuple, size_t> &hashed_genotype
 void
 get_llr(Relatedness &rel, std::map <Genotype_pair_tuple, size_t> hashed_genotypes);
 
+void
+get_95CI(Relatedness &rel, std::map <Genotype_pair_tuple, size_t> hashed_genotypes);
+
 #endif 
 

--- a/src/mapgd_0.4/mpi/mpi_relatedness.cc
+++ b/src/mapgd_0.4/mpi/mpi_relatedness.cc
@@ -168,7 +168,7 @@ int estimateRel(int argc, char *argv[])
 			} 
 			if ( chunk*taskid <= z && z < chunk*(taskid+1) )
 			{
-				hashed_genotypes=hash_genotypes(file_buffer, x, y, l2o);
+				hashed_genotypes=hash_genotypes(file_buffer, x, y, l2o, false);
 //				down_genotypes=downsample_genotypes(file_buffer, x, y, l2o);
 				relatedness.zero();
 				set_e(relatedness, hashed_genotypes);


### PR DESCRIPTION
Fixes missing function and paramter in mpi_relatedness.cc that prevents
compilling.